### PR TITLE
記事でタグの選択、表示

### DIFF
--- a/app/controllers/articles_controller.rb
+++ b/app/controllers/articles_controller.rb
@@ -51,4 +51,8 @@ class ArticlesController < ApplicationController
     params.require(:article).permit(:title, :content)
   end
 
+  def article_params
+    params.require(:article).permit(:title, :content, tag_ids: [])
+  end
+
 end

--- a/app/models/article.rb
+++ b/app/models/article.rb
@@ -3,4 +3,7 @@ class Article < ApplicationRecord
 
   belongs_to :user
 
+  has_many :tag_articles
+  has_many :tags, through: :tag_articles
+
 end

--- a/app/models/tag.rb
+++ b/app/models/tag.rb
@@ -1,0 +1,2 @@
+class Tag < ApplicationRecord
+end

--- a/app/models/tag.rb
+++ b/app/models/tag.rb
@@ -1,2 +1,4 @@
 class Tag < ApplicationRecord
+  has_many :tag_articles
+  has_many :articles, through: :tag_articles
 end

--- a/app/models/tag_article.rb
+++ b/app/models/tag_article.rb
@@ -1,0 +1,4 @@
+class TagArticle < ApplicationRecord
+  belongs_to :article
+  belongs_to :tag
+end

--- a/app/views/articles/_form.html.erb
+++ b/app/views/articles/_form.html.erb
@@ -12,6 +12,10 @@
   <% end %>
 
   <div class="mb-3">
+    <%= form.collection_check_boxes :tag_ids, Tag.all, :id, :name %>
+  </div>
+
+  <div class="mb-3">
     <%= form.label :title, class: "form-label" %>
     <%= form.text_field :title, class: "form-control" %>
   </div>

--- a/app/views/articles/index.html.erb
+++ b/app/views/articles/index.html.erb
@@ -12,7 +12,12 @@
   <tbody>
     <% @articles.each do |article| %>
       <tr>
-        <td><%= article.title %></td>
+        <td>
+          <%= article.title %>
+          <% article.tags.each do |tag| %>
+            <span class="badge rounded-pill bg-primary"><%= tag.name%></span>
+          <% end %>
+        </td>
         <td><%= article.content %></td>
         <td>
           <%= link_to '詳細', article, class: "btn btn-success" %>

--- a/app/views/articles/show.html.erb
+++ b/app/views/articles/show.html.erb
@@ -3,6 +3,9 @@
 <div class="card">
   <div class="card-header">
     <%= @article.title %>
+    <% @article.tags.each do |tag| %>
+      <span class="badge rounded-pill bg-primary"><%= tag.name%></span>
+    <% end %>
   </div>
   <div class="card-body">
     <%= @article.content %>

--- a/app/views/mypage/show.html.erb
+++ b/app/views/mypage/show.html.erb
@@ -13,7 +13,12 @@
   <tbody>
     <% @articles.each do |article| %>
       <tr>
-        <td><%= article.title %></td>
+        <td>
+          <%= article.title %>
+          <% article.tags.each do |tag| %>
+            <span class="badge rounded-pill bg-primary"><%= tag.name%></span>
+          <% end %>
+        </td>
         <td><%= article.content %></td>
         <td>
           <%= link_to '詳細', article, class: "btn btn-success" %>

--- a/db/migrate/20230818055330_create_tags.rb
+++ b/db/migrate/20230818055330_create_tags.rb
@@ -1,0 +1,9 @@
+class CreateTags < ActiveRecord::Migration[6.1]
+  def change
+    create_table :tags do |t|
+      t.string :name, null: false
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20230818055331_create_tag_articles.rb
+++ b/db/migrate/20230818055331_create_tag_articles.rb
@@ -1,0 +1,10 @@
+class CreateTagArticles < ActiveRecord::Migration[6.1]
+  def change
+    create_table :tag_articles do |t|
+      t.references :article, null: false, foreign_key: true
+      t.references :tag, null: false, foreign_key: true
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2023_08_18_055330) do
+ActiveRecord::Schema.define(version: 2023_08_18_055331) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -22,6 +22,15 @@ ActiveRecord::Schema.define(version: 2023_08_18_055330) do
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.index ["user_id"], name: "index_articles_on_user_id"
+  end
+
+  create_table "tag_articles", force: :cascade do |t|
+    t.bigint "article_id", null: false
+    t.bigint "tag_id", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["article_id"], name: "index_tag_articles_on_article_id"
+    t.index ["tag_id"], name: "index_tag_articles_on_tag_id"
   end
 
   create_table "tags", force: :cascade do |t|
@@ -43,4 +52,6 @@ ActiveRecord::Schema.define(version: 2023_08_18_055330) do
   end
 
   add_foreign_key "articles", "users"
+  add_foreign_key "tag_articles", "articles"
+  add_foreign_key "tag_articles", "tags"
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2023_08_18_055329) do
+ActiveRecord::Schema.define(version: 2023_08_18_055330) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -22,6 +22,12 @@ ActiveRecord::Schema.define(version: 2023_08_18_055329) do
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.index ["user_id"], name: "index_articles_on_user_id"
+  end
+
+  create_table "tags", force: :cascade do |t|
+    t.string "name", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
   end
 
   create_table "users", force: :cascade do |t|

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -13,6 +13,7 @@
     50.times do |m|
       user.articles.find_or_create_by!(title: "No.#{m + 1}: user00#{n + 1}の記事") do |user_cont|
         user_cont.content = "No.#{m + 1}: user00#{n + 1}の記事の本文"
+        user_cont.tag_ids = Tag.all.pluck(:id)
       end
     end
 end


### PR DESCRIPTION
## 概要

### tagのModelとValidationの実装
- tagのmodelとテーブルの作成、tagのnameは必須項目に設定

### 記事とタグのアソシエーションの追加
- articleのとtagを多対多に設定した
- articleとtagの中間ファイルとしてtag_articlesを作成し、tagとtag_articlesを1対多に設定し、tagとtag_articlesを1対多に設定した

### 記事とタグの紐づけての作成と表示
- タグを選択できるようにするためにcollection_check_boxesをviewファイルに追記
- タグを表示させるためにparams.require.permitの追記
- タグ付けに伴うseedファイルのすべてのタグを付ける.all.pluckの追記